### PR TITLE
IMS phone instantiation: add polling on base phone creation

### DIFF
--- a/src/java/com/android/internal/telephony/PhoneBase.java
+++ b/src/java/com/android/internal/telephony/PhoneBase.java
@@ -455,7 +455,13 @@ public abstract class PhoneBase extends Handler implements Phone {
         mUiccController = UiccController.getInstance();
         mUiccController.registerForIccChanged(this, EVENT_ICC_CHANGED, null);
 
-        // Monitor IMS service
+        // Monitor IMS service - but first poll to see if already up (could miss
+        // intent)
+        ImsManager imsManager = ImsManager.getInstance(mContext, getPhoneId());
+        if (imsManager != null && imsManager.isServiceAvailable()) {
+            mImsServiceReady = true;
+            updateImsPhone();
+        }
         IntentFilter filter = new IntentFilter();
         filter.addAction(ImsManager.ACTION_IMS_SERVICE_UP);
         filter.addAction(ImsManager.ACTION_IMS_SERVICE_DOWN);


### PR DESCRIPTION
Phone registers for notification of IMS service up and down. However,
there may be a race condition which causes the phone to be created after
the intents are alrady sent. Add polling in addition to listening to
broadcast intent.

Bug: 19447972
Change-Id: I0e12118bb11a22161cf2f389b9ca6f39442202e1